### PR TITLE
Rake: Fix Asciidoctor Invocation

### DIFF
--- a/_assets/rake/asciidoc.rb
+++ b/_assets/rake/asciidoc.rb
@@ -21,7 +21,7 @@ def AsciidoctorConvert(source_file, adoc_opts = "")
   TaskHeader("Converting to HTML: #{source_file}")
   src_dir = source_file.pathmap("%d")
   src_file = source_file.pathmap("%f")
-  adoc_opts = adoc_opts.chomp + " #{src_file}"
+  adoc_opts = adoc_opts.chomp + " \"#{src_file}\""
   cd "#{$repo_root}/#{src_dir}"
   begin
     stdout, stderr, status = Open3.capture3("asciidoctor #{adoc_opts}")


### PR DESCRIPTION
Tweak `_assets/rake/asciidoc.rb` module to enclose within
quotes the source file name when invoking Asciidoctor,
to prevent syntax errors on some platforms (see #11).